### PR TITLE
(SIMP-1436) Deliver ELG filters and dashboards with SIMP

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,6 @@
+* Sun Sep 25 2016 Ralph Wright <rwright.yamanishi@onyxpoint.com> - 0.1.1-0
+- A few minor fixes for seemless install
+- Added option to install SIMP dashboards
+- Added option to allow SIMP dashboards to be installed
 * Tue Jul 11 2016 Lucas Yamanishi <lucas.yamanishi@onyxpoint.com> - 0.1.0-0
 - Initial Release

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -100,7 +100,11 @@ class simp_grafana (
   $cfg               = {},
   $ldap_cfg          = {},
   $install_method    = 'repo',
-  $use_internet_repo = false
+  $use_internet_repo = false,
+#Need to set the version numbers until the upstream module can support "latest"
+  $version           = '3.1.1',
+  $rpm_iteration     = '1470047149',
+  $simp_dashboards   = false
 ) inherits ::simp_grafana::params {
 
   validate_array($client_nets)
@@ -146,6 +150,14 @@ class simp_grafana (
     cfg                 => $merged_cfg,
     ldap_cfg            => $merged_ldap_cfg,
     install_method      => $install_method,
-    manage_package_repo => $use_internet_repo
+    manage_package_repo => $use_internet_repo,
+    version             => $version,
+    rpm_iteration       => $rpm_iteration
+  }
+
+  if $simp_dashboards {
+    package { 'simp-grafana-dashboards':
+      ensure => 'latest',
+    }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,7 +34,7 @@ class simp_grafana::params {
   # Static defaults
   $cfg = {
     server       => {
-      http_port => 443,
+      http_port => 8443,
       protocol  => 'https',
       cert_file => "/etc/grafana/pki/public/${::fqdn}.pub",
       cert_key  => "/etc/grafana/pki/private/${::fqdn}.pem",
@@ -50,6 +50,8 @@ class simp_grafana::params {
     },
     'auth.basic' => { enabled => false },
     'auth.ldap'  => { enabled => $use_ldap },
+    #Allows SIMP dashboards to be read from the file system
+    'dashboards.json' => {enabled => true},
   }
 
   $ldap_group_mapping_defaults = [

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-simp_grafana",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author":  "simp",
   "summary": "A profile module to integrate Grafana with SIMP",
   "license": "Apache-2.0",

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -40,7 +40,7 @@ HOSTS:
         gpgkeys:
           - https://getfedora.org/static/352C64E5.txt
       pcloud:
-        url: https://packagecloud.io/simp-project/5_1_X_Dependencies/el/7/$basearch
+        url: https://packagecloud.io/simp-project/5_X_Dependencies/el/7/$basearch
         gpgkeys:
           - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
           - https://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -19,11 +19,11 @@ describe 'simp_grafana' do
         it_behaves_like 'a structured module'
         it { is_expected.to contain_class('simp_grafana').with_client_nets(['127.0.0.0/8']) }
         it { is_expected.to contain_class('simp_grafana::config::firewall') }
-        it { is_expected.to create_iptables__add_tcp_stateful_listen('allow_simp_grafana_tcp_connections').with_dports('443') }
-        it 'grants CAP_NET_BIND_SERVICE to grafana-server' do
-          is_expected.to create_exec('grant_grafana_cap_net_bind_service').with(
-            'command' => 'setcap cap_net_bind_service=+ep /usr/sbin/grafana-server',
-            'unless'  => 'getcap /usr/sbin/grafana-server | fgrep cap_net_bind_service+ep',
+        it { is_expected.to create_iptables__add_tcp_stateful_listen('allow_simp_grafana_tcp_connections').with_dports('8443') }
+        it 'grants revoke_grafana_cap to grafana-server' do
+          is_expected.to create_exec('revoke_grafana_caps').with(
+            'command' => 'setcap -r /usr/sbin/grafana-server',
+            'onlyif'  => 'getcap /usr/sbin/grafana-server | fgrep cap_net_bind_service+ep',
             'path'    => ['/usr/bin', '/usr/sbin', '/bin', '/sbin']
           ).that_requires('Class[grafana::config]').that_notifies('Class[grafana::service]')
         end
@@ -35,7 +35,7 @@ describe 'simp_grafana' do
         let(:params) { { :enable_firewall => false } }
         it_behaves_like 'a structured module'
         it { is_expected.not_to contain_class('simp_grafana::config::firewall') }
-        it { is_expected.not_to create_iptables__add_tcp_stateful_listen('allow_simp_grafana_tcp_connections').with_dports('443') }
+        it { is_expected.not_to create_iptables__add_tcp_stateful_listen('allow_simp_grafana_tcp_connections').with_dports('8443') }
       end
 
       context 'when set to use a non-default port' do


### PR DESCRIPTION
- Applies grafana setting to enable file based dashboards.
- Installs SIMP grafana dashboard RPMs
- Changes the default port for grafana
- Sets the grafana version that has been tested with SIMP

SIMP-1436 #comment Goes along with grafana dashboards and logstash filters
