### PR TITLE
(SIMP-1738) Correctly bind gems in `5.X Gemfile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,59 +1,38 @@
 # ------------------------------------------------------------------------------
-# Environment variables:
-#   SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
-#   PUPPET_VERSION   | specifies the version of the puppet gem to load
-# ------------------------------------------------------------------------------
 # NOTE: SIMP Puppet rake tasks support ruby 2.0 and ruby 2.1
 # ------------------------------------------------------------------------------
-puppetversion = ENV.key?('PUPPET_VERSION') ? ENV['PUPPET_VERSION'].to_s : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  gem 'rake'
-  gem 'puppet', puppetversion
-  gem 'rspec', '< 3.2.0'
-  gem 'rspec-puppet'
-  gem 'hiera-puppet-helper'
-  gem 'puppetlabs_spec_helper'
-  gem 'metadata-json-lint'
-  gem 'simp-rspec-puppet-facts', '~> 1.3'
-
-  gem 'toml'
-
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2')
-    gem 'rubocop', :require => false
-  end
-
-  # simp-rake-helpers does not suport puppet 2.7.X
-  if ENV['PUPPET_VERSION'].to_s.scan(/\d+/).first != '2' &&
-     # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
-     # TODO: fix upstream deps (parallel in simp-rake-helpers)
-     RUBY_VERSION.sub(/\.\d+$/, '') != '1.8'
-    gem 'simp-rake-helpers'
-  end
+  gem "rake"
+  gem 'puppet', ENV.fetch('PUPPET_VERSION',  '~>3')
+  gem "rspec", '< 3.2.0'
+  gem "rspec-puppet"
+  gem "hiera-puppet-helper"
+  gem "puppetlabs_spec_helper"
+  gem "metadata-json-lint"
+  gem "simp-rspec-puppet-facts", ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 1.3')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 2.5')
 end
 
 group :development do
-  gem 'travis'
-  gem 'travis-lint'
-  gem 'travish'
-  gem 'vagrant-wrapper'
-  gem 'puppet-blacksmith'
-  gem 'guard-rake'
+  gem "travis"
+  gem "travis-lint"
+  gem "travish"
+  gem "puppet-blacksmith"
+  gem "guard-rake"
   gem 'pry'
   gem 'pry-doc'
 
   # `listen` is a dependency of `guard`
   # from `listen` 3.1+, `ruby_dep` requires Ruby version >= 2.2.3, ~> 2.2
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2')
-    gem 'listen', '~> 3.0.6', :require => false
-  end
+  gem 'listen', '~> 3.0.6'
 end
 
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', '>= 1.0.5'
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.5')
 end


### PR DESCRIPTION
This commit pins the `simp-rake-helpers` gem in the `Gemfile` so that
subsequent upgrades will not break `bundle update` inside the `5.X`
branch.

SIMP-1738 #comment Bound gems in pupmod-simp-simp_grafana `Gemfile`
SIMP-1810 #close
