### PR TITLE
(SIMP-1684) Remove pupmod-simp-sysctl

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -44,7 +44,6 @@ fixtures:
       repo: https://github.com/simp/puppetlabs-stdlib
       branch: simp-master
     stunnel: https://github.com/simp/pupmod-simp-stunnel
-    sysctl: https://github.com/simp/pupmod-simp-sysctl
     tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers
   symlinks:
     simp_grafana: "#{source_dir}"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Dec 02 2016 Nick Markowski <nmarkowski@keywcorp.com> - 1.0.1-0
+- Removed pupmod-simp-sysctl in favor of augeas-sysctl
+
 * Wed Nov 23 2016 Jeanne Greulich <jgreulich@onyxpoint.com> - 1.0.0-0
 - Update major version for SIMP 6
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_grafana",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "SIMP Team",
   "summary": "A profile module to integrate Grafana with SIMP",
   "license": "Apache-2.0",


### PR DESCRIPTION
Replaced sysctl::value with augeas 'sysctl' native type.

SIMP-1684 #comment done in simp-grafana
SIMP-2241 #close