### PR TITLE
(SIMP-3119) Update simp_grafana for latest Grafana and Elasticsearch

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -22,7 +22,7 @@ fixtures:
     file_concat:
       repo: https://github.com/simp/puppet-lib-file_concat
       ref: simp6.0.0-1.0.1
-    grafana: 
+    grafana:
       repo: https://github.com/simp/puppet-grafana
       ref: v3.0.0
     haveged:
@@ -52,18 +52,16 @@ fixtures:
     rsyslog:
       repo: https://github.com/simp/pupmod-simp-rsyslog
       ref: 7.0.2
-    simp: 
+    simp:
       repo: https://github.com/simp/pupmod-simp-simp
       ref: 4.0.0
     simp_apache:
       repo: https://github.com/simp/pupmod-simp-apache
       ref: 6.0.0
-#FIXME: Use PR for 5.X update to pupmod-simp-simp_elasticsearch until this is merged.
-#    simp_elasticsearch: https://github.com/simp/pupmod-simp-simp_elasticsearch
-    simp_elasticsearch: 
+    simp_elasticsearch:
       repo: https://github.com/lnemsick-simp/pupmod-simp-simp_elasticsearch
-      branch: SIMP-3048
-    simp_openldap: 
+      branch: master
+    simp_openldap:
       repo: https://github.com/simp/pupmod-simp-simp_openldap
       ref: 6.0.2
     simpcat:

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -23,11 +23,7 @@ fixtures:
       repo: https://github.com/simp/puppet-lib-file_concat
       ref: simp6.0.0-1.0.1
     grafana: 
-# FIXME Use newer version than is available in our fork
-# voxpupuli/puppet-grafana is a fork of bfraser/puppet-grafana
-# that is (1) more current than its parent and (2) the
-# forge-recommended module
-      repo: https://github.com/voxpupuli/puppet-grafana
+      repo: https://github.com/simp/puppet-grafana
       ref: v3.0.0
     haveged:
       repo: https://github.com/simp/puppet-haveged

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,35 +1,89 @@
 ---
 fixtures:
   repositories:
-    auditd: https://github.com/simp/pupmod-simp-auditd
-    augeasproviders_core: https://github.com/simp/augeasproviders_core
-    augeasproviders_grub: https://github.com/simp/augeasproviders_grub
-    concat: https://github.com/puppetlabs/puppetlabs-concat
-    datacat: https://github.com/simp/puppet-datacat
+    auditd:
+      repo: https://github.com/simp/pupmod-simp-auditd
+      ref: 7.0.1
+    augeasproviders_core:
+      repo: https://github.com/simp/augeasproviders_core
+      ref: simp6.0.0-2.1.3
+    augeasproviders_grub:
+      repo: https://github.com/simp/augeasproviders_grub
+      ref: simp6.0.0-2.4.0
+    concat:
+      repo: https://github.com/simp/puppetlabs-concat
+      ref: simp6.0.0-2.2.0
+    datacat:
+      repo: https://github.com/simp/puppet-datacat
+      ref: simp6.0.0-0.6.2
     elasticsearch:
       repo: https://github.com/simp/puppet-elasticsearch
-      branch: simp-master
-    file_concat: https://github.com/simp/puppet-lib-file_concat
-    grafana: https://github.com/simp/puppet-grafana
+      ref: 5.2.0
+    file_concat:
+      repo: https://github.com/simp/puppet-lib-file_concat
+      ref: simp6.0.0-1.0.1
+    grafana: 
+# FIXME Use newer version than is available in our fork
+# voxpupuli/puppet-grafana is a fork of bfraser/puppet-grafana
+# that is (1) more current than its parent and (2) the
+# forge-recommended module
+      repo: https://github.com/voxpupuli/puppet-grafana
+      ref: v3.0.0
     haveged:
       repo: https://github.com/simp/puppet-haveged
-      branch: simp-master
-    iptables: https://github.com/simp/pupmod-simp-iptables
-    java: https://github.com/simp/puppetlabs-java
-    logrotate: https://github.com/simp/pupmod-simp-logrotate
-    oddjob: https://github.com/simp/pupmod-simp-oddjob
-    pam: https://github.com/simp/pupmod-simp-pam
-    pki: https://github.com/simp/pupmod-simp-pki
-    rsync: https://github.com/simp/pupmod-simp-rsync
-    rsyslog: https://github.com/simp/pupmod-simp-rsyslog
-    simp: https://github.com/simp/pupmod-simp-simp
-    simp_apache: https://github.com/simp/pupmod-simp-apache
-    simp_elasticsearch: https://github.com/simp/pupmod-simp-simp_elasticsearch
-    simp_openldap: https://github.com/simp/pupmod-simp-simp_openldap
-    simpcat: https://github.com/simp/pupmod-simp-concat
-    simplib: https://github.com/simp/pupmod-simp-simplib
-    stdlib: https://github.com/simp/puppetlabs-stdlib
-    stunnel: https://github.com/simp/pupmod-simp-stunnel
-    tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers
+      ref: 0.4.0
+    iptables:
+      repo: https://github.com/simp/pupmod-simp-iptables
+      ref: 6.0.1
+    java:
+      repo: https://github.com/simp/puppetlabs-java
+      ref: simp-1.6.0-post1
+    logrotate:
+      repo: https://github.com/simp/pupmod-simp-logrotate
+      ref: 6.0.0
+    oddjob:
+      repo: https://github.com/simp/pupmod-simp-oddjob
+      ref: 2.0.0
+    pam:
+      repo: https://github.com/simp/pupmod-simp-pam
+      ref: 6.0.2
+    pki:
+      repo: https://github.com/simp/pupmod-simp-pki
+      ref: 6.0.0
+    rsync:
+      repo: https://github.com/simp/pupmod-simp-rsync
+      ref: 6.0.2
+    rsyslog:
+      repo: https://github.com/simp/pupmod-simp-rsyslog
+      ref: 7.0.2
+    simp: 
+      repo: https://github.com/simp/pupmod-simp-simp
+      ref: 4.0.0
+    simp_apache:
+      repo: https://github.com/simp/pupmod-simp-apache
+      ref: 6.0.0
+#FIXME: Use PR for 5.X update to pupmod-simp-simp_elasticsearch until this is merged.
+#    simp_elasticsearch: https://github.com/simp/pupmod-simp-simp_elasticsearch
+    simp_elasticsearch: 
+      repo: https://github.com/lnemsick-simp/pupmod-simp-simp_elasticsearch
+      branch: SIMP-3048
+    simp_openldap: 
+      repo: https://github.com/simp/pupmod-simp-simp_openldap
+      ref: 6.0.2
+    simpcat:
+      repo: https://github.com/simp/pupmod-simp-concat
+      ref: 6.0.0
+    simplib:
+      repo: https://github.com/simp/pupmod-simp-simplib
+      ref: 3.2.0
+    stdlib:
+      repo: https://github.com/simp/puppetlabs-stdlib
+      ref: simp6.0.0-4.13.1
+    stunnel:
+      repo: https://github.com/simp/pupmod-simp-stunnel
+      ref: 6.0.1
+    tcpwrappers:
+      repo: https://github.com/simp/pupmod-simp-tcpwrappers
+      ref: 6.0.0
   symlinks:
     simp_grafana: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
-#  PE/SIMP versions
-#  app    pup  ruby
-# 2015.2  4.3  2.1.7
-# 2015.3  4.3  2.1.8
-# 2016.1  4.4  2.1.9
-# 2016.2  4.5  2.1.9
-# S6.0.0  4.7  2.1.9
+# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
+# ------------------------------------------------------------------------------
+#  release    pup   ruby      eol
+# PE 2015.2   4.2   2.1.7  2017-03-17
+# PE 2015.3   4.3   2.1.8  2017-03-17
+# PE 2016.1   4.4   2.1.9  2017-03-17 (yes: all three EOL on the same day!)
+# PE 2016.2   4.5   2.1.9  2017-04-30
+# PE 2016.4   4.7   2.1.9  TBD (LTS)
+# PE 2016.5   4.8   2.1.9  TBD
+# SIMP6.0.0   4.8   2.1.9  TBD
 ---
 language: ruby
 sudo: false
@@ -24,17 +27,15 @@ env:
     - STRICT_VARIABLES=yes
     - TRUSTED_NODE_DATA=yes
   matrix:
+    - PUPPET_VERSION="~> 4.8.2"
     - PUPPET_VERSION="~> 4.7.0"
     - PUPPET_VERSION="~> 4.5.0"
-    - PUPPET_VERSION="~> 3.8.0"
     - PUPPET_VERSION="~> 4.4.0"
     - PUPPET_VERSION="~> 4.3.0"
-    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
 matrix:
   fast_finish: true
   allow_failures:
+    - env: PUPPET_VERSION="~> 4.7.0"
     - env: PUPPET_VERSION="~> 4.5.0"
-    - env: PUPPET_VERSION="~> 3.8.0"
     - env: PUPPET_VERSION="~> 4.4.0"
     - env: PUPPET_VERSION="~> 4.3.0"
-    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue May 09 2017 Liz Nemsick <liz.nemsick-simp@gmail.com> - 1.0.4-0
+- Update to latest Grafana (4.2.0) and Elasticsearch (5.4.0)
+- simp_grafana::version now defaults to 'latest'
+
 * Fri Mar 23 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.3-0
 - Fixed the Beaker tests
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,22 +1,22 @@
+# NOTE: SIMP Puppet rake tasks support ruby 2.1.9
 # ------------------------------------------------------------------------------
-# NOTE: SIMP Puppet rake tasks support ruby 2.0 and ruby 2.1
-# ------------------------------------------------------------------------------
-gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
+gem_sources   = ENV.fetch('GEM_SERVERS','https://rubygems.org').split(/[, ]+/)
 
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
   gem 'rake'
-  gem 'puppet', ENV.fetch('PUPPET_VERSION',  '~>4')
+  gem 'puppet', ENV.fetch('PUPPET_VERSION', '~>4.8.0') # Default to SIMP 6
   gem 'rspec'
   gem 'rspec-puppet'
+  gem 'puppet-strings'
   gem 'hiera-puppet-helper'
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 1.3')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 3.0')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 3.5')
 
   # extra gems (defined in build/pupmod_metadata/extra_gems.yaml)
   gem 'toml'
@@ -27,7 +27,6 @@ group :development do
   gem 'travis-lint'
   gem 'travish'
   gem 'puppet-blacksmith'
-  gem 'puppet-strings'
   gem 'guard-rake'
   gem 'pry'
   gem 'pry-doc'
@@ -38,8 +37,7 @@ group :development do
 end
 
 group :system_tests do
-  # This patch is required to fix Beaker's broken `aio` handling
-  gem 'beaker', :git => 'https://github.com/trevor-vaughan/beaker.git', :branch => 'BKR-931-2.51.0'
+  gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.5')
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.7')
 end

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,5 +1,5 @@
-Requires: pupmod-bfraser-grafana < 3.0.0-0
-Requires: pupmod-bfraser-grafana >= 2.5.0-0
+Requires: pupmod-puppet-grafana < 4.0.0-0
+Requires: pupmod-puppet-grafana >= 3.0.0-0
 Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
 Requires: pupmod-puppetlabs-stdlib >= 4.13.1-0
 Requires: pupmod-simp-iptables < 7.0.0-0

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -129,7 +129,7 @@ class simp_grafana (
   Hash                          $ldap_cfg                = {},
   String                        $install_method          = 'repo',
   Boolean                       $use_internet_repo       = false,
-  String                        $version                 = 'latest',
+  String                        $version                 = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
   String                        $rpm_iteration           = '1',
   Boolean                       $simp_dashboards         = false
 ) inherits ::simp_grafana::params {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,8 +1,8 @@
 ## Class: simp_grafana
 #
 # This module acts as a SIMP wrapper ("profile") for the Puppet, Inc. Approved
-# Grafana module written and maintained by Bill Fraser.  It sets a basline of
-# secure defaults and integrates Grafan with other SIMP components.
+# Grafana module written and maintained by Bill Fraser.  It sets a baseline of
+# secure defaults and integrates Grafana with other SIMP components.
 #
 # @note If SIMP integration is not required, direct use of the component Grafana
 #   module is advised.
@@ -27,7 +27,7 @@
 #   (in CIDR notation) permitted access.
 #
 # @param firewall If true, manage firewall rules to
-#   acommodate simp_grafana.
+#   accommodate simp_grafana.
 #
 # @param pki
 #   * If 'simp', include SIMP's pki module and use pki::copy to manage
@@ -66,8 +66,7 @@
 #   merged with the SIMP defaults in `::simp_grafana::params`.
 #
 # @param ldap_cfg A passthrough to the Grafana component module.
-#   Unlike the `cfg` param, this does not currently merge with any defaults, but
-#   is provided as a convinence.
+#   merged with the SIMP defaults in `::simp_grafana::params`.
 #   @note If using Puppet 3.x, Integer values in this Hash must be declared with
 #     arithmetic expression to avoid converison to a String.  For example, to
 #     set a value to `1`, the value should be declared as `0 + 1`.
@@ -76,7 +75,7 @@
 #   the installation method of Grafana to a repository by default since this is
 #   the SIMP preferred method for installing packages.
 #
-# @param use_intenet_repo If set, allow the ::grafana module to point
+# @param use_internet_repo If set, allow the ::grafana module to point
 #   to the appropriate package repository on the Internet automatically.
 #
 ## Examples
@@ -130,9 +129,8 @@ class simp_grafana (
   Hash                          $ldap_cfg                = {},
   String                        $install_method          = 'repo',
   Boolean                       $use_internet_repo       = false,
-  # Need to set the version numbers until the upstream module can support "latest"
-  String                        $version                 = '3.1.1',
-  String                        $rpm_iteration           = '1470047149',
+  String                        $version                 = 'latest',
+  String                        $rpm_iteration           = '1',
   Boolean                       $simp_dashboards         = false
 ) inherits ::simp_grafana::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class simp_grafana::params {
   $bind_dn = simplib::lookup('simp_options::ldap::bind_dn', { 'default_value' => "uid=%s,${base_dn}" } )
   $bind_pw = simplib::lookup('simp_options::ldap::bind_pw', { 'default_value' => undef } )
 
-  $ldap_urls   = hiera_array('simp_options::ldap::uri', [''])
+  $ldap_urls   = simplib::lookup('simp_options::ldap::uri', { 'default_value' => [''] } )
   $ldap_url    = $ldap_urls[0]
   $ldap_server = inline_template(
     '<%= @ldap_url.match(/(([[:alnum:]][[:alnum:]-]{0,254})?[[:alnum:]]\.)+(([[:alnum:]][[:alnum:]-]{0,254})?[[:alnum:]])\.?/) %>'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -55,8 +55,8 @@ class simp_grafana::params {
     'auth.ldap'  => { enabled => $ldap },
     #Allows SIMP dashboards to be read from the file system
     'dashboards.json' => { enabled => true },
-     analytics   => { reporting_enabled => false },
-     snapshot    => { external_enabled => false },
+    analytics   => { reporting_enabled => false },
+    snapshot    => { external_enabled => false },
   }
 
   $ldap_group_mapping_defaults = [

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -55,6 +55,8 @@ class simp_grafana::params {
     'auth.ldap'  => { enabled => $ldap },
     #Allows SIMP dashboards to be read from the file system
     'dashboards.json' => { enabled => true },
+     analytics   => { reporting_enabled => false },
+     snapshot    => { external_enabled => false },
   }
 
   $ldap_group_mapping_defaults = [

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_grafana",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "SIMP Team",
   "summary": "A profile module to integrate Grafana with SIMP",
   "license": "Apache-2.0",
@@ -12,8 +12,8 @@
   ],
   "dependencies": [
     {
-      "name": "bfraser/grafana",
-      "version_requirement": ">= 2.5.0 < 3.0.0"
+      "name": "puppet/grafana",
+      "version_requirement": ">= 3.0.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -13,11 +13,10 @@ HOSTS:
         mirrorlist: https://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=$basearch&country=us
         gpgkeys:
           - https://getfedora.org/static/352C64E5.txt
-      simp:
-        url: https://dl.bintray.com/simp/5.1.X
+      simp-deps:
+        baseurl: https://packagecloud.io/simp-project/6_X_Dependencies/el/7/x86_64
         gpgkeys:
           - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://getfedora.org/static/352C64E5.txt
 
   grafana:
     roles:
@@ -38,17 +37,10 @@ HOSTS:
         mirrorlist: https://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=$basearch&country=us
         gpgkeys:
           - https://getfedora.org/static/352C64E5.txt
-      pcloud:
-        url: https://packagecloud.io/simp-project/5_X_Dependencies/el/7/$basearch
+      simp-deps:
+        baseurl: https://packagecloud.io/simp-project/6_X_Dependencies/el/7/x86_64
         gpgkeys:
           - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs
-          - https://getfedora.org/static/352C64E5.txt
-      simp:
-        url: https://dl.bintray.com/simp/5.1.X
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://getfedora.org/static/352C64E5.txt
 
   elasticsearch-server:
     roles:
@@ -64,15 +56,10 @@ HOSTS:
         mirrorlist: https://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=$basearch&country=us
         gpgkeys:
           - https://getfedora.org/static/352C64E5.txt
-      simp:
-        url: https://dl.bintray.com/simp/5.1.X
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://getfedora.org/static/352C64E5.txt
       elasticsearch:
-        url: https://packages.elastic.co/elasticsearch/2.x/centos
+        baseurl:  https://artifacts.elastic.co/packages/5.x/yum
         gpgkeys:
-          - https://packages.elastic.co/GPG-KEY-elasticsearch
+          - https://artifacts.elastic.co/GPG-KEY-elasticsearch
 
 CONFIG:
   log_level: verbose


### PR DESCRIPTION
- Use voxpupuli/puppet-grafana which is a puppetforge approved module
  and a newer fork of bfraser/puppet-grafana
- Set simp_grafana::version to 'latest', now that grafana module supports it
- Fix a few typos in documentation
- Update YUM URLs and gpgkeys used in acceptance test