### PR TITLE
(SIMP-3289) Wrong pupmod-simp-simp_elasticsearch url in .fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -59,7 +59,7 @@ fixtures:
       repo: https://github.com/simp/pupmod-simp-apache
       ref: 6.0.0
     simp_elasticsearch:
-      repo: https://github.com/lnemsick-simp/pupmod-simp-simp_elasticsearch
+      repo: https://github.com/simp/pupmod-simp-simp_elasticsearch
       branch: master
     simp_openldap:
       repo: https://github.com/simp/pupmod-simp-simp_openldap


### PR DESCRIPTION
Wrong URL was causing acceptance test to fail, when
lnemsick-simp/pupmod-simp-simp_elasticsearch/master was not
current.