### PR TITLE
(SIMP-3903) Update test deps and fix acceptance tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,83 +1,48 @@
 ---
 fixtures:
   repositories:
-    auditd:
-      repo: https://github.com/simp/pupmod-simp-auditd
-      ref: 7.0.1
-    augeasproviders_core:
-      repo: https://github.com/simp/augeasproviders_core
-      ref: simp6.0.0-2.1.3
-    augeasproviders_grub:
-      repo: https://github.com/simp/augeasproviders_grub
-      ref: simp6.0.0-2.4.0
+    auditd: https://github.com/simp/pupmod-simp-auditd
+    augeasproviders_core: https://github.com/simp/augeasproviders_core
+    augeasproviders_grub: https://github.com/simp/augeasproviders_grub
     concat:
+      # master is beyond 4.1.1, but has breaking changes to
+      # how fragments are ordered (MODULES-6625)
       repo: https://github.com/simp/puppetlabs-concat
-      ref: simp6.0.0-2.2.0
+      ref: 4.1.1
     datacat:
       repo: https://github.com/simp/puppet-datacat
       ref: simp6.0.0-0.6.2
     elasticsearch:
       repo: https://github.com/simp/puppet-elasticsearch
-      ref: 5.2.0
+      ref: 5.5.0
     file_concat:
       repo: https://github.com/simp/puppet-lib-file_concat
-      ref: simp6.0.0-1.0.1
+      ref: simp-1.0.1
     grafana:
       repo: https://github.com/simp/puppet-grafana
-      ref: v3.0.0
-    haveged:
-      repo: https://github.com/simp/puppet-haveged
-      ref: 0.4.0
-    iptables:
-      repo: https://github.com/simp/pupmod-simp-iptables
-      ref: 6.0.1
+      # v4.1.0 has a bug in grafana_datasource that causes
+      # one of the acceptance test manifests to not be idempotent
+      # (failing the test!).
+      ref: v4.0.3
+    haveged: https://github.com/simp/pupmod-simp-haveged
+    iptables: https://github.com/simp/pupmod-simp-iptables
     java:
       repo: https://github.com/simp/puppetlabs-java
-      ref: simp-1.6.0-post1
-    logrotate:
-      repo: https://github.com/simp/pupmod-simp-logrotate
-      ref: 6.0.0
-    oddjob:
-      repo: https://github.com/simp/pupmod-simp-oddjob
-      ref: 2.0.0
-    pam:
-      repo: https://github.com/simp/pupmod-simp-pam
-      ref: 6.0.2
-    pki:
-      repo: https://github.com/simp/pupmod-simp-pki
-      ref: 6.0.0
-    rsync:
-      repo: https://github.com/simp/pupmod-simp-rsync
-      ref: 6.0.2
-    rsyslog:
-      repo: https://github.com/simp/pupmod-simp-rsyslog
-      ref: 7.0.2
-    simp:
-      repo: https://github.com/simp/pupmod-simp-simp
-      ref: 4.0.0
-    simp_apache:
-      repo: https://github.com/simp/pupmod-simp-apache
-      ref: 6.0.0
-    simp_elasticsearch:
-      repo: https://github.com/simp/pupmod-simp-simp_elasticsearch
-      branch: master
-    simp_openldap:
-      repo: https://github.com/simp/pupmod-simp-simp_openldap
-      ref: 6.0.2
-    simpcat:
-      repo: https://github.com/simp/pupmod-simp-concat
-      ref: 6.0.0
-    simplib:
-      repo: https://github.com/simp/pupmod-simp-simplib
-      ref: 3.2.0
-    stdlib:
-      repo: https://github.com/simp/puppetlabs-stdlib
-      ref: simp6.0.0-4.13.1
-    stunnel:
-      repo: https://github.com/simp/pupmod-simp-stunnel
-      ref: 6.0.1
-    tcpwrappers:
-      repo: https://github.com/simp/pupmod-simp-tcpwrappers
-      ref: 6.0.0
+      ref: 2.4.0
+    logrotate: https://github.com/simp/pupmod-simp-logrotate
+    oddjob: https://github.com/simp/pupmod-simp-oddjob
+    pam: https://github.com/simp/pupmod-simp-pam
+    pki: https://github.com/simp/pupmod-simp-pki
+    rsync: https://github.com/simp/pupmod-simp-rsync
+    rsyslog: https://github.com/simp/pupmod-simp-rsyslog
+    simp: https://github.com/simp/pupmod-simp-simp
+    simp_apache: https://github.com/simp/pupmod-simp-apache
+    simp_elasticsearch: https://github.com/simp/pupmod-simp-simp_elasticsearch
+    simp_openldap: https://github.com/simp/pupmod-simp-simp_openldap
+    simpcat: https://github.com/simp/pupmod-simp-concat
+    simplib: https://github.com/simp/pupmod-simp-simplib
+    stdlib: https://github.com/simp/puppetlabs-stdlib
+    stunnel: https://github.com/simp/pupmod-simp-stunnel
+    tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers
   symlinks:
     simp_grafana: "#{source_dir}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,97 +1,207 @@
+# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
 #
+# https://puppet.com/docs/pe/2017.3/overview/component_versions_in_recent_pe_releases.html
+# https://puppet.com/misc/puppet-enterprise-lifecycle
+# https://puppet.com/docs/pe/2017.3/overview/getting_support_for_pe.html#standard-releases-and-long-term-support-releases
+# ------------------------------------------------------------------------------
+#  release    pup   ruby      eol
+# PE 2016.4   4.7   2.1.9  2018-10  (LTS)
+# SIMP6.0.0   4.8   2.1.9  TBD
+# PE 2017.2   4.10  2.1.9  2018-02-21
+# PE 2017.3   5.3   2.4.1  2018-07
+# PE 2018.1   ???   ?????  ????-??  (LTS)
 ---
-puppet-syntax: 
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
+.cache_bundler: &cache_bundler
+  cache:
+    untracked: true
+    # An attempt at caching between runs (ala Travis CI)
+    key: "${CI_PROJECT_NAMESPACE}__bundler"
+    paths:
+      - '.vendor'
+      - 'vendor'
+
+.setup_bundler_env: &setup_bundler_env
+  before_script:
+    - '(find .vendor | wc -l) || :'
+    - bundle || gem install bundler --no-rdoc --no-ri
+    - rm -f Gemfile.lock
+    - rm -rf pkg/
+    - bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}"
+
+.validation_checks: &validation_checks
+  script:
     - bundle exec rake syntax
-puppet-lint: 
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
+    - bundle exec rake check:dot_underscore
+    - bundle exec rake check:test_file
+    - bundle exec rake pkg:check_version
+    - bundle exec rake pkg:compare_latest_tag
     - bundle exec rake lint
-puppet-metadata: 
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
-    - bundle exec rake metadata
-unit-test-ruby-2.1:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
-    - bundle exec rake spec
-unit-test-ruby-2.2:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.2
-  allow_failure: true
-  script: 
-    - bundle install
-    - bundle exec rake spec
-unit-test-ruby-2.3:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.3
-  allow_failure: true
-  script: 
-    - bundle install
+    - bundle exec rake clean
+    - bundle exec puppet module build
+
+.spec_tests: &spec_tests
+  script:
     - bundle exec rake spec
 
-# For PE LTS Support
+stages:
+  - validation
+  - unit
+  - acceptance
+  - deploy
+
+# Puppet 4.7 for PE 2016.4 LTS Support (EOL: 2018-10-21)
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
-puppet4.7-syntax: 
-  stage: test
-  tags: 
+# --------------------------------------
+pup4.7-validation:
+  stage: validation
+  tags:
     - docker
   image: ruby:2.1
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake syntax
-unit-test-puppet4.7-ruby-2.1:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
-unit-test-puppet4.7-ruby-2.2:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.2
-  allow_failure: true
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
-unit-test-puppet4.7-ruby-2.3:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.3
-  allow_failure: true
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
+  variables:
+    PUPPET_VERSION: '~> 4.7.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
 
-acceptance-test: 
-  stage: test
-  tags: 
+pup4.7-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.7.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+
+
+# Puppet 4.8 for SIMP 6.0 + 6.1 support
+# --------------------------------------
+pup4.8-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.8.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+
+pup4.8-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.8.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+
+
+# Puppet 4.10 for PE 2017.2 support (EOL:2018-02-21)
+# See: https://puppet.com/misc/puppet-enterprise-lifecycle
+# --------------------------------------
+pup4.10-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.10.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+
+pup4.10-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.10.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+
+
+# Puppet 5.3 for PE 2017.3 support (EOL: 2018-07)
+# See: https://puppet.com/misc/puppet-enterprise-lifecycle
+# --------------------------------------
+pup5.3-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.3.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+
+pup5.3-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.3.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+  allow_failure: true
+
+
+# Keep an eye on the latest puppet 5
+# ----------------------------------
+pup5.latest-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+  allow_failure: true
+
+pup5.latest-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+  allow_failure: true
+
+
+
+# Acceptance tests
+# ==============================================================================
+acceptance-default:
+  stage: acceptance
+  tags:
     - beaker
-  script: 
-    - bundle install --no-binstubs --path=vendor
-    - bundle exec rake acceptance
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10'
+  script:
+    - bundle exec rake beaker:suites[default]
+
+acceptance-fips-default:
+  stage: acceptance
+  tags:
+    - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10'
+    BEAKER_fips: 'yes'
+  script:
+    - bundle exec rake beaker:suites[default]

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -2,7 +2,6 @@
 --relative
 --no-class_inherits_from_params_class-check
 --no-140chars-check
---no-empty_string-check
 --no-trailing_comma-check
 # This is here because the code can't handle lookups in parameters and we have
 # a LOT of those

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,48 +8,85 @@
 # PE 2017.2   4.10  2.1.9  TBD
 ---
 language: ruby
-sudo: false
 cache: bundler
-before_script:
-  - bundle update
+sudo: false
+
 bundler_args: --without development system_tests --path .vendor
-before_install: rm Gemfile.lock || true
-script:
-  - bundle exec rake test
+
+
 notifications:
   email: false
-rvm:
-  - 2.1.9
-env:
-  global:
-    - STRICT_VARIABLES=yes
-  matrix:
-    - PUPPET_VERSION="~> 4.8.2" FORGE_PUBLISH=true
-    - PUPPET_VERSION="~> 4.10.0"
-    - PUPPET_VERSION="~> 4.9.2"
-    - PUPPET_VERSION="~> 4.7.0"
-matrix:
-  fast_finish: true
 
-before_deploy:
-  - 'bundle exec rake metadata_lint'
-  - 'bundle exec rake clobber'
-  - 'bundle exec rake spec_clean'
-  - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
-  - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
-deploy:
-  - provider: puppetforge
-    user: simp
-    password:
-        secure: "EYG7mnyOyXml1WfB6dnPtrh33JpwVkG18oIorC1oIVlDaG0lNg0EW1yzyfG9xMiSnVjBfU8OwtLUYdW7YEp0y579cNDbHLyNjZX7JoYR+UbqGdQoNKOj3AGPMXCLsVbhTHtoROX72IuXAcfZKqjCTmjeCsf4BVBajUnV1M/G7958xfo5aoungPp36Y74tLAB+SM/+ylT3kWkbMFSesQpDqMH5+hNgi5GVJBWdgl9ItNNk1mGak+FGGbvKxVSk6rdFgKu8pCB+ovjdZYXX2N8xCzAbirpUjSb4TPompTnnoBk5NNHwZrqFMssHyjSFJY4hJb9KO0hCo/OECfnU80eeaSWFZj1NjGbECp2wEkQzZAfzelUNdHZojDPshouYgLmIDS2w95UpffWr7QPDqMksrOrDP/7OtAhyvMt/2BR2Y9jJIwZnixGTRNEMYLNvcREvJYwwS6hODgfXL0HHLpw15uL76Jreg1vgRoBRS09oo1hkNMObtMVTt+sLH6ZNwKaq2AO+lmcUq30+2LcOJ3N3WOogQoFlPGeA5BGmLRIIpaGUrWnyZ/yLhPO5JjQyY4L4c3lTFNPjjv5V1/LMM1TOCGh+i73pMPWnp1Z3Gie6PXJsJoQTm9GsJKr1xuDiQgdvvaVolIDuOfDyyqri/osfBnioAXyro8ZEXNzJHHXHCU="
-    on:
-      tags: true
+addons:
+  apt:
+    packages:
+      - rpm
+
+before_install:
+  - rm -f Gemfile.lock
+
+jobs:
+  allow_failures:
+    - env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
+
+  include:
+    - stage: check
+      rvm: 2.4.1
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5"
+      script:
+        - bundle exec rake check:dot_underscore
+        - bundle exec rake check:test_file
+        - bundle exec rake pkg:check_version
+        - bundle exec rake lint
+        - bundle exec rake metadata_lint
+        - bundle exec rake pkg:compare_latest_tag
+        - bundle exec rake pkg:create_tag_changelog
+        - bundle exec puppet module build
+
+    - stage: spec
+      rvm: 2.4.1
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
       rvm: 2.1.9
-      condition: '($SKIP_FORGE_PUBLISH != true) && ($FORGE_PUBLISH = true)'
-  - provider: releases
-    api_key:
-        secure: "aD3v2Jn4IOJxJCZYi7XUqUIiqHmjtjcsWTYitLFwTvlwVX8qJKthXnbktzqInVCty0RI28uL7fAXXMCsAXe18OJK1KIw50SybfTJAQ0mauaIKO92eB9ZIouTFk9Rvg3fqolIn4RffDwmqVcxMjFXK7PRRtowxIZkkD/7gSZeHHJaJTgmBB/nRK+DItajl72PIg2dE9Uiv0j+l6UaxySw9SAgFiZvZPK9YEf3TPpWFQlcN+Pq6Mwo47HlWRKnqNeb/eG3+Hp5+drQmGtI5abFnZBxYSBRSRu9crCCc8qE52w2GlRUoAUMm5PYTSHYlmw6iudtg2PoCUi953ZKR4MZaVKIQ+pq3RUvGpb77gM/0YlZk2LG3qH8BqZKRdgFBjFi6Favwk7Zb+w62GOtTJ8eIMwdxk7oCQNqX8IVn7lRUgefmz4++Ad5UqzB2ZCobWJR4kS5TUQt6jUaGCP26WAe8X6DhPuVWt5QbO+DTWq3Ma7NvR1ogGxB31uqEuC+ct+i2yeUabLXVkK98OkzEtZK7hLEhxTiSDuuhM6HuSGqYsc+WJkruwYD0t5d1uATnEySHcrv6/6Su5vuEIzUX4B0Vax9oo+kV7fQo4uWKxlB7uuwbq8DbwSv0i7FZwlma3agotG9I7zWi5AaWs3glPIIg3jZak/CrT8CM+7T4m/n8bs="
-    skip_cleanup: true
-    on:
-      tags: true
-      condition: '($SKIP_FORGE_PUBLISH != true) && ($FORGE_PUBLISH = true)'
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.10.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.9.2"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.7.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: deploy
+      rvm: 2.4.1
+      script:
+        - true
+      before_deploy:
+        - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
+        - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
+      deploy:
+        - provider: releases
+          api_key:
+            secure: "aD3v2Jn4IOJxJCZYi7XUqUIiqHmjtjcsWTYitLFwTvlwVX8qJKthXnbktzqInVCty0RI28uL7fAXXMCsAXe18OJK1KIw50SybfTJAQ0mauaIKO92eB9ZIouTFk9Rvg3fqolIn4RffDwmqVcxMjFXK7PRRtowxIZkkD/7gSZeHHJaJTgmBB/nRK+DItajl72PIg2dE9Uiv0j+l6UaxySw9SAgFiZvZPK9YEf3TPpWFQlcN+Pq6Mwo47HlWRKnqNeb/eG3+Hp5+drQmGtI5abFnZBxYSBRSRu9crCCc8qE52w2GlRUoAUMm5PYTSHYlmw6iudtg2PoCUi953ZKR4MZaVKIQ+pq3RUvGpb77gM/0YlZk2LG3qH8BqZKRdgFBjFi6Favwk7Zb+w62GOtTJ8eIMwdxk7oCQNqX8IVn7lRUgefmz4++Ad5UqzB2ZCobWJR4kS5TUQt6jUaGCP26WAe8X6DhPuVWt5QbO+DTWq3Ma7NvR1ogGxB31uqEuC+ct+i2yeUabLXVkK98OkzEtZK7hLEhxTiSDuuhM6HuSGqYsc+WJkruwYD0t5d1uATnEySHcrv6/6Su5vuEIzUX4B0Vax9oo+kV7fQo4uWKxlB7uuwbq8DbwSv0i7FZwlma3agotG9I7zWi5AaWs3glPIIg3jZak/CrT8CM+7T4m/n8bs="
+          skip_cleanup: true
+          on:
+            tags: true
+            condition: '($SKIP_FORGE_PUBLISH != true)'
+        - provider: puppetforge
+          user: simp
+          password:
+            secure: "EYG7mnyOyXml1WfB6dnPtrh33JpwVkG18oIorC1oIVlDaG0lNg0EW1yzyfG9xMiSnVjBfU8OwtLUYdW7YEp0y579cNDbHLyNjZX7JoYR+UbqGdQoNKOj3AGPMXCLsVbhTHtoROX72IuXAcfZKqjCTmjeCsf4BVBajUnV1M/G7958xfo5aoungPp36Y74tLAB+SM/+ylT3kWkbMFSesQpDqMH5+hNgi5GVJBWdgl9ItNNk1mGak+FGGbvKxVSk6rdFgKu8pCB+ovjdZYXX2N8xCzAbirpUjSb4TPompTnnoBk5NNHwZrqFMssHyjSFJY4hJb9KO0hCo/OECfnU80eeaSWFZj1NjGbECp2wEkQzZAfzelUNdHZojDPshouYgLmIDS2w95UpffWr7QPDqMksrOrDP/7OtAhyvMt/2BR2Y9jJIwZnixGTRNEMYLNvcREvJYwwS6hODgfXL0HHLpw15uL76Jreg1vgRoBRS09oo1hkNMObtMVTt+sLH6ZNwKaq2AO+lmcUq30+2LcOJ3N3WOogQoFlPGeA5BGmLRIIpaGUrWnyZ/yLhPO5JjQyY4L4c3lTFNPjjv5V1/LMM1TOCGh+i73pMPWnp1Z3Gie6PXJsJoQTm9GsJKr1xuDiQgdvvaVolIDuOfDyyqri/osfBnioAXyro8ZEXNzJHHXHCU="
+          on:
+            tags: true
+            rvm: 2.4.1
+            condition: '($SKIP_FORGE_PUBLISH != true)'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Feb 16 2018 Liz Nemsick <liz.nemsick-simp@gmail.com> - 1.0.5-0
+- Update upper range of puppet/grafana module dependency to < 5.0.0
+
 * Wed Jul 12 2017 Liz Nemsick <liz.nemsick-simp@gmail.com> - 1.0.4-0
 - Workaround 2-pass grafana rpm install issue in acceptance tests
 - Update README to reflect SIMP 6 global catalysts.

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :test do
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.0')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 4.0')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.2', '< 6.0'])
 
   # extra gems (defined in build/pupmod_metadata/extra_gems.yaml)
   gem 'toml'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,8 +1,8 @@
 ## Class: simp_grafana
 #
 # This module acts as a SIMP wrapper ("profile") for the Puppet, Inc. Approved
-# Grafana module written and maintained by Bill Fraser.  It sets a baseline of
-# secure defaults and integrates Grafana with other SIMP components.
+# Grafana module written by Bill Fraser and maintained by Vox Pupuli.  It sets
+# baseline of secure defaults and integrates Grafana with other SIMP components.
 #
 # @note If SIMP integration is not required, direct use of the component Grafana
 #   module is advised.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_grafana",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "SIMP Team",
   "summary": "A profile module to integrate Grafana with SIMP",
   "license": "Apache-2.0",
@@ -13,7 +13,7 @@
   "dependencies": [
     {
       "name": "puppet/grafana",
-      "version_requirement": ">= 3.0.0 < 4.0.0"
+      "version_requirement": ">= 3.0.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -33,7 +33,6 @@ HOSTS:
         gpgkeys:
           - https://packagecloud.io/gpg.key
           - https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana
-          - https://raw.githubusercontent.com/simp/simp-core/master/src/assets/simp-gpgkeys/GPGKEYS/RPM-GPG-KEY-grafana-legacy
       epel:
         mirrorlist: https://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=$basearch&country=us
         gpgkeys:


### PR DESCRIPTION
* Update to concat 4.1.1. and grafana v4.0.3
* Fix acceptance test.
  The acceptance tests run with the latest-and-greatest grafana RPM,
  (current grafana 4.6.3). Beginning with Grafana 4.6.2, TLS server
  verification was turned on by default in communications with data
  sources.  This broke the Elasticsearch/Grafana integration test.

SIMP-3903 #comment Update to puppet-concat 4.1.1
SIMP-4022 #close   simp_grafana acceptance test failure
SIMP-3806 #comment Update to puppet-grafana v4.0.3