### PR TITLE
(SIMP-5299) updated $app_pki_external_source type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Sep 11 2018 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 1.0.6-0
+- Updated $app_pki_external_source to accept any string. This matches the
+  functionality of pki::copy.
+
 * Thu Jun 14 2018 Nick Miller <nick.miller@onyxpoint.com> - 1.0.6-0
 - Update systemd fixtures and CI assets
 - Add support for Puppet 5 and OEL

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -126,7 +126,7 @@ Default value: simplib::lookup('simp_options::pki', { 'default_value' => false }
 
 ##### `app_pki_external_source`
 
-Data type: `Stdlib::Absolutepath`
+Data type: `String`
 
 * If pki = 'simp' or true, this is the directory from which certs will be
   copied, via pki::copy.  Defaults to /etc/pki/simp/x509.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -130,7 +130,7 @@ class simp_grafana (
   Simplib::Netlist              $trusted_nets            = $::simp_grafana::params::trusted_nets,
   Boolean                       $firewall                = $::simp_grafana::params::firewall,
   Variant[Boolean,Enum['simp']] $pki                     = simplib::lookup('simp_options::pki', { 'default_value' => false }),
-  Stdlib::Absolutepath          $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
+  String                        $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
   Hash                          $cfg                     = {},
   Hash                          $ldap_cfg                = {},
   String                        $install_method          = 'repo',


### PR DESCRIPTION
- Updated $app_pki_external_source to accept any string. This matches the
  functionality of pki::copy.

SIMP-5296 #comment Updated simp_grafana
SIMP-5299 #close