### PR TITLE
WIP (SIMP-6030) (SIMP-6171) (SIMP-6921) Update metadata versions.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -13,11 +13,11 @@
   "dependencies": [
     {
       "name": "puppet/grafana",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.0.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 6.0.0"
+      "version_requirement": ">= 4.13.1 < 7.0.0"
     },
     {
       "name": "simp/iptables",
@@ -62,7 +62,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 6.0.0"
+      "version_requirement": ">= 4.7.0 < 7.0.0"
     }
   ]
 }


### PR DESCRIPTION
Huh.  Somehow, [this code](https://github.com/simp/pupmod-simp-simp_grafana/blob/master/spec/acceptance/suites/default/05_fake_elasticsearch_server_spec.rb#L12-L14) isn't delivering [this data](https://github.com/simp/pupmod-simp-simp_grafana/blob/master/spec/fixtures/hieradata/elasticsearch_server.yaml.erb#L4) to [this test](https://github.com/simp/pupmod-simp-simp_grafana/blob/master/spec/fixtures/manifests/elasticsearch_server.pp#L1):
> `Class[Simp_elasticsearch]: expects a value for parameter 'cluster_name'`